### PR TITLE
Fixed byte concat issue with message

### DIFF
--- a/vertica_python/vertica/messages/message.py
+++ b/vertica_python/vertica/messages/message.py
@@ -55,4 +55,4 @@ class BackendMessage(Message):
 
 class FrontendMessage(Message):
     def to_bytes(self):
-        return self.message_string('')
+        return self.message_string(b'')


### PR DESCRIPTION
I believe this is msg type needs to a byte not a string. I was getting an error message when closing the connection, trying to concat an empty string with bytes.